### PR TITLE
Fix: Correct build errors in AnalyticsSection and ui/chart

### DIFF
--- a/src/components/AnalyticsSection.tsx
+++ b/src/components/AnalyticsSection.tsx
@@ -367,7 +367,6 @@ const AnalyticsSection = () => {
                   </Pie>
                   <Tooltip />
                 </PieChart>
-              </ResponsiveContainer>
             ) : (
               <div className="h-64 flex items-center justify-center text-gray-500">
                 <div className="text-center">
@@ -399,7 +398,6 @@ const AnalyticsSection = () => {
                 <Line type="monotone" dataKey="created" stroke="#8b5cf6" strokeWidth={2} name="Created" />
                 <Line type="monotone" dataKey="completed" stroke="#10b981" strokeWidth={2} name="Completed" />
               </LineChart>
-            </ResponsiveContainer>
           </CardContent>
         </Card>
       </div>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -36,10 +36,10 @@ const ChartContainer = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div"> & {
     config: ChartConfig
-    children: React.ComponentProps<
+    // children: React.ComponentProps< // This line was the source of the error
     // typeof RechartsPrimitive.ResponsiveContainer // Removed ResponsiveContainer
     // >["children"]
-    React.ReactElement<RechartsPrimitive.ChartProps> // Expect a single Recharts chart element
+    children: React.ReactElement<RechartsPrimitive.ChartProps> // Expect a single Recharts chart element
   }
 >(({ id, className, children, config, ...props }, ref) => {
   const uniqueId = React.useId()


### PR DESCRIPTION
- Removed orphaned </ResponsiveContainer> tag in AnalyticsSection.tsx to resolve 'Unterminated regular expression' error.
- Corrected TypeScript type definition for ChartContainer children prop in ui/chart.tsx to resolve 'Expected ";" but found "."' error.

These changes address build failures identified after previous commit.