### PR TITLE
Fix: Resolve runtime error DialogDescription not defined

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";


### PR DESCRIPTION
Added DialogDescription to the import statement in TaskManager.tsx to fix a 'ReferenceError: DialogDescription is not defined' that occurred at runtime.