### PR TITLE
Fix: Add Task dialog display and accessibility from voice command

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogPortal, DialogOverlay } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -364,12 +364,14 @@ const TaskManager = ({ showAddDialog = false, onShowAddDialogChange }: TaskManag
       </div>
 
       <Dialog open={showAddDialog} onOpenChange={onShowAddDialogChange}>
-        <DialogContent 
-          className="w-[95vw] max-w-md mx-auto bg-white/95 dark:bg-gray-800/95 backdrop-blur-lg border-purple-200/50 dark:border-purple-700/50"
-          aria-describedby="add-task-description"
-        >
-          <DialogHeader>
-            <DialogTitle>Add New Task</DialogTitle>
+        <DialogPortal>
+          <DialogOverlay />
+          <DialogContent
+            className="w-[95vw] max-w-md mx-auto bg-white/95 dark:bg-gray-800/95 backdrop-blur-lg border-purple-200/50 dark:border-purple-700/50"
+            aria-describedby="add-task-description"
+          >
+            <DialogHeader>
+              <DialogTitle>Add New Task</DialogTitle>
             <DialogDescription id="add-task-description">
               Fill in the details below to add a new task to your list.
             </DialogDescription>
@@ -473,6 +475,7 @@ const TaskManager = ({ showAddDialog = false, onShowAddDialogChange }: TaskManag
             </div>
           </div>
         </DialogContent>
+        </DialogPortal>
       </Dialog>
 
       {editingTask && (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -62,10 +62,7 @@ const Dashboard = () => {
       console.log("Voice add task triggered - forcing dialog immediately");
       // Force the dialog to show immediately regardless of current tab
       setShowAddTask(true);
-      // Then switch to tasks tab if not already there
-      if (activeTab !== "tasks") {
-        setActiveTab("tasks");
-      }
+      // No longer switching to tasks tab automatically
     };
     const handleVoiceTabChange = (event: CustomEvent) => {
       const { tab } = event.detail;
@@ -349,10 +346,7 @@ const Dashboard = () => {
             setShowVoiceCommands(false);
             // Show dialog immediately
             setShowAddTask(true);
-            // Switch to tasks tab if needed
-            if (activeTab !== "tasks") {
-              setActiveTab("tasks");
-            }
+            // No longer switching to tasks tab automatically
           }} onStartTimer={() => {
             const timerEvent = new CustomEvent('start-pomodoro-timer');
             window.dispatchEvent(timerEvent);


### PR DESCRIPTION
- Modified Dashboard.tsx to prevent automatic tab switching to 'Tasks' when 'add task' is triggered by voice. The dialog state is set, but the active tab remains unchanged.
- Updated TaskManager.tsx to explicitly use DialogPortal and DialogOverlay for the 'Add Task' dialog. This ensures it renders correctly as a global overlay even if the 'Tasks' tab is inactive, and aims to resolve the 'aria-describedby' console warning.

These changes address the issue where the 'Add Task' dialog would not appear immediately via voice command unless the 'Tasks' tab was active, and also fixes the related accessibility warning.