### PR TITLE
Fix: Ensure Add Task dialog accessibility and visibility from inactiv…

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -285,7 +285,7 @@ const Dashboard = () => {
             </TabsTrigger>
           </TabsList>
 
-          <TabsContent value="tasks" className="scroll-animate">
+          <TabsContent value="tasks" className="scroll-animate" forceMount>
             <div id="task-section">
               <TaskManager showAddDialog={showAddTask} onShowAddDialogChange={setShowAddTask} />
             </div>


### PR DESCRIPTION
…e tabs

- Added `forceMount` to the 'Tasks' tab's `TabsContent` in `Dashboard.tsx`. This ensures that the TaskManager and its Add Task dialog's descriptive elements are always in the DOM, which is expected to resolve the `aria-describedby` warning when the dialog is triggered while the Tasks tab is inactive.
- Previous changes in this branch already ensured the dialog uses portals and that voice commands do not automatically switch tabs.

This set of changes aims to allow the Add Task dialog to appear immediately via voice command from any tab, without switching tabs, and without the `aria-describedby` console warning.