### PR TITLE
This commit fixes a bug where the AIAssistant component was still try…

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -21,7 +21,7 @@ const AIAssistant = () => {
   const [responses, setResponses] = useState<AIResponse[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isModelLoading, setIsModelLoading] = useState(false);
-  const [selectedModel, setSelectedModel] = useState('flan-t5');
+  const [selectedModel, setSelectedModel] = useState('academic-qa');
   const [isInitialized, setIsInitialized] = useState(false);
   const { toast } = useToast();
 


### PR DESCRIPTION
…ing to load the old 'flan-t5' model, which had been removed.

The `selectedModel` state in `AIAssistant.tsx` is now initialized with the new `'academic-qa'` model key. This ensures that the correct model is loaded when the component mounts.