### PR TITLE
This commit resolves an error where the AI Assistant failed to load t…

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -26,7 +26,7 @@ class AIService {
 
   private configs: Record<string, AIServiceConfig> = {
     'academic-qa': {
-      model: 'distilbert-base-cased-distilled-squad',
+      model: 'Xenova/distilbert-base-cased-distilled-squad',
       task: 'question-answering',
       maxTokens: 100,
     },


### PR DESCRIPTION
…he question-answering model.

The previously selected model, 'distilbert-base-cased-distilled-squad', was not available in the required ONNX format for use with transformers.js in the browser.

This has been corrected by switching to 'Xenova/distilbert-base-cased-distilled-squad', which is a version of the same model that has been converted to ONNX and is compatible with transformers.js.