### PR TITLE
fix: Improve password reset error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -247,11 +247,18 @@ const App = () => {
         if (error.message.includes('Invalid API key')) {
           return { error: { message: 'Authentication service is temporarily unavailable. Please try again later.' } };
         }
+        // Check for network errors which might indicate a redirect URL issue
+        if (error.name === 'AuthRetryableFetchError' || error.message.includes('NetworkError')) {
+          return { error: { message: 'Network error. Please check your connection and ensure the app URL is in your Supabase project\'s redirect list.' } };
+        }
       }
       
       return { error };
-    } catch (error) {
+    } catch (error: any) {
       console.error('[App] Password reset exception:', error);
+      if (error.name === 'AuthRetryableFetchError' || error.message.includes('NetworkError')) {
+        return { error: { message: 'Network error. Please check your connection and ensure the app URL is in your Supabase project\'s redirect list.' } };
+      }
       return { error: { message: 'An unexpected error occurred. Please try again.' } };
     }
   };


### PR DESCRIPTION
The password reset feature was failing with a generic "NetworkError" message. This is often caused by a misconfiguration in the Supabase project settings where the application's URL is not included in the allowed redirect URLs.

This change improves the error handling within the `resetPassword` function. It now specifically catches the `AuthRetryableFetchError` and provides a more informative error message, guiding the user to check their Supabase configuration and resolve the issue.