### PR TITLE
feat: Close calendar popover on date selection

### DIFF
--- a/src/components/TaskEditDialog.tsx
+++ b/src/components/TaskEditDialog.tsx
@@ -34,6 +34,7 @@ interface TaskEditDialogProps {
 
 const TaskEditDialog = ({ task, isOpen, onClose, onSave }: TaskEditDialogProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [editData, setEditData] = useState({
     title: "",
     description: "",
@@ -152,7 +153,7 @@ const TaskEditDialog = ({ task, isOpen, onClose, onSave }: TaskEditDialogProps) 
           </div>
           <div className="space-y-2">
             <Label>Due Date (Optional)</Label>
-            <Popover>
+            <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
               <PopoverTrigger asChild>
                 <Button variant="outline" className="w-full justify-start text-left text-sm">
                   <CalendarIcon className="mr-2 h-4 w-4" />
@@ -163,7 +164,10 @@ const TaskEditDialog = ({ task, isOpen, onClose, onSave }: TaskEditDialogProps) 
                 <Calendar
                   mode="single"
                   selected={editData.dueDate}
-                  onSelect={(date) => setEditData({...editData, dueDate: date})}
+                  onSelect={(date) => {
+                    setEditData({ ...editData, dueDate: date });
+                    setIsCalendarOpen(false);
+                  }}
                   initialFocus
                 />
               </PopoverContent>

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -27,6 +27,11 @@ interface Task {
   createdAt: Date;
 }
 
+type ParsedTask = Omit<Task, 'dueDate' | 'createdAt'> & {
+  dueDate?: string;
+  createdAt: string;
+};
+
 interface TaskManagerProps {
   showAddDialog?: boolean;
   onShowAddDialogChange?: (show: boolean) => void;
@@ -42,6 +47,7 @@ const TaskManager = ({ showAddDialog = false, onShowAddDialogChange, activeTab }
   const [filterPriority, setFilterPriority] = useState<string>("all");
   const [filterCategory, setFilterCategory] = useState<string>("all");
   const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
 
   // Form state
   const [newTask, setNewTask] = useState({
@@ -60,7 +66,7 @@ const TaskManager = ({ showAddDialog = false, onShowAddDialogChange, activeTab }
       if (savedTasks) {
         try {
           const parsedTasks = JSON.parse(savedTasks);
-          const tasksWithDates = parsedTasks.map((task: any) => ({
+          const tasksWithDates = parsedTasks.map((task: ParsedTask) => ({
             ...task,
             dueDate: task.dueDate ? new Date(task.dueDate) : undefined,
             createdAt: new Date(task.createdAt)
@@ -434,7 +440,7 @@ const TaskManager = ({ showAddDialog = false, onShowAddDialogChange, activeTab }
             
             <div>
               <Label>Due Date (Optional)</Label>
-              <Popover>
+              <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
                 <PopoverTrigger asChild>
                   <Button variant="outline" className="w-full justify-start text-left">
                     <CalendarIcon className="mr-2 h-4 w-4" />
@@ -445,7 +451,10 @@ const TaskManager = ({ showAddDialog = false, onShowAddDialogChange, activeTab }
                   <Calendar
                     mode="single"
                     selected={newTask.dueDate}
-                    onSelect={(date) => setNewTask({...newTask, dueDate: date})}
+                    onSelect={(date) => {
+                      setNewTask({ ...newTask, dueDate: date });
+                      setIsCalendarOpen(false);
+                    }}
                     initialFocus
                   />
                 </PopoverContent>


### PR DESCRIPTION
This commit updates the 'Add Task' and 'Edit Task' dialogs to automatically close the calendar popover when a date is selected.

This is achieved by introducing a state variable to control the open state of the `Popover` component and updating it in the `onSelect` handler of the `Calendar` component.

This improves the user experience by removing the need to manually close the popover after selecting a date.