### PR TITLE
Fix: Correctly display user's full name in chat

### DIFF
--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -263,7 +263,7 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                   const showDate = index === 0 || 
                     formatDate(message.created_at) !== formatDate(messages[index - 1].created_at);
                   const isOwnMessage = message.user_id === user?.id;
-                  const displayName = message.profiles?.full_name || message.profiles?.username;
+                  const displayName = message.profiles?.full_name;
                   const displayInitial = displayName?.charAt(0)?.toUpperCase() || 'U';
 
 

--- a/src/hooks/useRealtimeMessages.ts
+++ b/src/hooks/useRealtimeMessages.ts
@@ -15,7 +15,6 @@ interface Message {
   profiles?: {
     id?: string;
     full_name: string | null;
-    username?: string | null;
     avatar_url?: string | null;
   };
 }
@@ -42,7 +41,6 @@ export const useRealtimeMessages = (groupId: string | null) => {
           profiles (
             id,
             full_name,
-            username,
             avatar_url
           )
         `)


### PR DESCRIPTION
This commit resolves a bug where the application would crash when fetching chat messages due to a non-existent `username` column being queried from the `profiles` table.

The fix involves two main changes:
1.  The database query in `useRealtimeMessages.ts` has been updated to select the `full_name` column instead of `username`, aligning it with the actual database schema.
2.  The `GroupChat.tsx` component has been updated to exclusively use the `full_name` field for displaying the sender's name, ensuring consistency with the "manage members" section as requested by the user.

These changes fix the error and ensure that the correct user identifier is displayed in the chat.