### PR TITLE
Fix: Use full_name for chat display name

### DIFF
--- a/supabase/migrations/20250927035522_create_get_message_with_profile_function.sql
+++ b/supabase/migrations/20250927035522_create_get_message_with_profile_function.sql
@@ -46,7 +46,6 @@ BEGIN
       jsonb_build_object(
         'id', p.id,
         'full_name', p.full_name,
-        'username', p.username,
         'avatar_url', p.avatar_url
       ) as profiles
     FROM


### PR DESCRIPTION
This commit resolves a bug causing chat messages to fail to load and display "Unknown User" for real-time messages. The root cause was the application attempting to query and use a non-existent `username` column from the `profiles` table.

The fix aligns the application with the database schema by consistently using the `full_name` column, as confirmed to be the correct approach.

Changes include:
- Updating the initial message query in `useRealtimeMessages.ts` to fetch `full_name`.
- Updating the `get_message_with_profile` SQL function to return `full_name` for real-time messages.
- Updating the `GroupChat.tsx` component to display `full_name`.