### PR TITLE
Fix: Ensure chat display name is always synchronized

### DIFF
--- a/supabase/migrations/20250927080100_add_profile_update_trigger.sql
+++ b/supabase/migrations/20250927080100_add_profile_update_trigger.sql
@@ -1,0 +1,27 @@
+-- This migration creates a trigger that updates the public.profiles table
+-- whenever a user's metadata is updated in the auth.users table.
+-- This ensures that the full_name and avatar_url are kept in sync.
+
+-- 1. Create the trigger function
+create or replace function public.update_public_profile_on_user_update()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Update the corresponding row in public.profiles
+  update public.profiles
+  set
+    full_name = new.raw_user_meta_data->>'full_name',
+    avatar_url = new.raw_user_meta_data->>'avatar_url',
+    updated_at = now()
+  where id = new.id;
+  return new;
+end;
+$$;
+
+-- 2. Create the trigger on the auth.users table
+create trigger on_auth_user_updated
+  after update on auth.users
+  for each row execute function public.update_public_profile_on_user_update();


### PR DESCRIPTION
This commit resolves a persistent bug where chat messages would display "Unknown User" because of a data synchronization issue between the `auth.users` table and the `public.profiles` table.

The solution involves two key parts:
1.  A new database migration that creates a trigger (`on_auth_user_updated`). This trigger automatically updates a user's `full_name` and `avatar_url` in the `public.profiles` table whenever their information in `auth.users` is updated. This ensures data consistency for all future changes.
2.  The frontend code and existing database functions have been updated to consistently use the `full_name` field from the `profiles` table, which is now guaranteed to be up-to-date.

This provides a robust and permanent fix for the issue, ensuring that user display names are always correct in the chat.