### PR TITLE
fix: Resolve Supabase query ambiguity and UI overlap

### DIFF
--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -263,7 +263,7 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                   const showDate = index === 0 || 
                     formatDate(message.created_at) !== formatDate(messages[index - 1].created_at);
                   const isOwnMessage = message.user_id === user?.id;
-                  const displayName = message.profiles?.full_name || message.profiles?.email;
+                  const displayName = message.profiles?.full_name || (message.profiles?.email ? message.profiles.email.split('@')[0] : null);
                   
                   // Get the best display name for this message
                   const getBestDisplayName = () => {
@@ -271,15 +271,14 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                       // For own messages, try to get the user's name from their profile data
                       return displayName || 
                              user?.user_metadata?.full_name || 
-                             user?.email?.split('@')[0] || 
-                             'You';
+                             (user?.email ? user.email.split('@')[0] : 'You');
                     }
                     // For other users, only show if we have actual profile data
                     if (displayName && displayName.trim() !== '') {
                       return displayName;
                     }
-                    // If no profile data, show a loading state
-                    return 'Loading...';
+                    // If no profile data, show a fallback
+                    return `User ${message.user_id.substring(0, 8)}`;
                   };
                   
                   

--- a/src/hooks/useRealtimeMessages.ts
+++ b/src/hooks/useRealtimeMessages.ts
@@ -39,7 +39,7 @@ export const useRealtimeMessages = (groupId: string | null) => {
         .from('messages')
         .select(`
           *,
-          profiles (
+          profiles!messages_user_id_fkey (
             id,
             full_name,
             email,

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -138,7 +138,7 @@ const Dashboard = () => {
 
       <div className="p-4 space-y-6 h-full flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between animate-fade-in-up">
+        <div className="flex items-center justify-between animate-fade-in-up pr-10">
           <h1 className="text-2xl font-bold tracking-tight bg-gradient-to-r from-primary via-purple-500 to-blue-600 bg-clip-text text-transparent animate-gradient">
             Aurora
           </h1>


### PR DESCRIPTION
This commit addresses two separate issues:

1.  **Fixes Supabase query ambiguity:** The query to fetch messages in `useRealtimeMessages.ts` was causing an error due to an ambiguous relationship between the `messages` and `profiles` tables. This has been resolved by explicitly specifying the foreign key relationship in the query.

2.  **Corrects UI overlap in the dashboard:** The "Live" badge in the sidebar header of the dashboard was overlapping with the close button on mobile views. Added right padding to the header to ensure there is enough space and prevent the elements from colliding.

3.  **Improves user display name fallback:** Updated the `GroupChat.tsx` component to provide a better fallback for usernames when profile information is not available, displaying a truncated user ID instead of "Unknown User".