### PR TITLE
feat: Display user's name in group chat with fallback

### DIFF
--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -272,7 +272,7 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                       }
                     : message.profiles;
 
-                  const displayName = getProfileName(profileForName);
+                  const displayName = getProfileName(profileForName, message.user_id);
                   const displayInitial = displayName.charAt(0).toUpperCase();
 
                   return (

--- a/src/components/GroupChat.tsx
+++ b/src/components/GroupChat.tsx
@@ -10,7 +10,7 @@ import { useRealtimeMessages } from '@/hooks/useRealtimeMessages';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { Send, ArrowLeft, Users, Crown, Edit, Check, X } from 'lucide-react';
-import { generateAvatarUrl } from '@/lib/utils';
+import { generateAvatarUrl, getProfileName } from '@/lib/utils';
 
 interface GroupChatProps {
   groupId: string;
@@ -263,36 +263,17 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                   const showDate = index === 0 || 
                     formatDate(message.created_at) !== formatDate(messages[index - 1].created_at);
                   const isOwnMessage = message.user_id === user?.id;
-                  const displayName = message.profiles?.full_name || (message.profiles?.email ? message.profiles.email.split('@')[0] : null);
-                  
-                  // Get the best display name for this message
-                  const getBestDisplayName = () => {
-                    if (isOwnMessage) {
-                      // For own messages, try to get the user's name from their profile data
-                      return displayName || 
-                             user?.user_metadata?.full_name || 
-                             (user?.email ? user.email.split('@')[0] : 'You');
-                    }
-                    // For other users, only show if we have actual profile data
-                    if (displayName && displayName.trim() !== '') {
-                      return displayName;
-                    }
-                    // If no profile data, show a fallback
-                    return `User ${message.user_id.substring(0, 8)}`;
-                  };
-                  
-                  
-                  
-                  
-                  // Get the best display name for avatar initial
-                  const getAvatarInitial = () => {
-                    const bestName = getBestDisplayName();
-                    return bestName.charAt(0).toUpperCase();
-                  };
-                  
-                  const displayInitial = getAvatarInitial();
-                  
 
+                  // For own messages, create a composite profile object to get the best name
+                  const profileForName = isOwnMessage
+                    ? {
+                        full_name: message.profiles?.full_name || user?.user_metadata?.full_name,
+                        email: message.profiles?.email || user?.email,
+                      }
+                    : message.profiles;
+
+                  const displayName = getProfileName(profileForName);
+                  const displayInitial = displayName.charAt(0).toUpperCase();
 
                   return (
                     <div key={message.id}>
@@ -307,7 +288,7 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                         <Avatar className="h-8 w-8 flex-shrink-0">
                           <AvatarImage
                             src={message.profiles?.avatar_url || generateAvatarUrl(message.user_id)}
-                            alt={displayName || 'User'}
+                            alt={displayName}
                           />
                           <AvatarFallback className="text-xs">
                             {displayInitial}
@@ -316,7 +297,7 @@ export default function GroupChat({ groupId, onBack }: GroupChatProps) {
                         <div className={`flex-1 max-w-[70%] ${isOwnMessage ? 'text-right' : ''}`}>
                           <div className={`flex items-center gap-2 mb-1 ${isOwnMessage ? 'flex-row-reverse' : ''}`}>
                             <span className="text-sm font-medium">
-                              {getBestDisplayName()}
+                              {displayName}
                             </span>
                             <span className="text-xs text-muted-foreground">
                               {formatTime(message.created_at)}

--- a/src/hooks/useRealtimeMessages.ts
+++ b/src/hooks/useRealtimeMessages.ts
@@ -59,37 +59,21 @@ export const useRealtimeMessages = (groupId: string | null) => {
         const messagesWithProfiles = await Promise.all(
           messages.map(async (message) => {
             if (!message.profiles || (!message.profiles.full_name && !message.profiles.email)) {
-              console.log('Missing profile data for message, fetching user info:', message.id);
-              
+              console.log('Missing or incomplete profile for message, fetching full user info:', message.id);
               try {
-                // Try direct profiles table access
-                const { data: profileData, error: profileError } = await supabase
-                  .from('profiles')
-                  .select('id, full_name, email, avatar_url')
-                  .eq('id', message.user_id)
-                  .maybeSingle();
+                const { data: profileData, error: rpcError } = await supabase
+                  .rpc('get_user_profile_info', { p_user_id: message.user_id })
+                  .single();
 
-                if (!profileError && profileData) {
+                if (profileData && !rpcError) {
                   message.profiles = profileData;
-                  console.log('Successfully fetched profile data for message:', message.id, profileData);
                 } else {
-                  console.log('Could not fetch profile data for message:', message.id, profileError);
-                  // Create empty profile if no data is available
-                  message.profiles = {
-                    id: message.user_id,
-                    full_name: '',
-                    email: '',
-                    avatar_url: ''
-                  };
+                  if (rpcError) console.error('Error fetching profile info via RPC:', rpcError.message);
+                  message.profiles = { id: message.user_id, full_name: null, email: null, avatar_url: null };
                 }
-              } catch (error) {
-                console.log('Error fetching user data for message:', message.id, error);
-                message.profiles = {
-                  id: message.user_id,
-                  full_name: '',
-                  email: '',
-                  avatar_url: ''
-                };
+              } catch (e) {
+                console.error('Exception fetching profile info:', e);
+                message.profiles = { id: message.user_id, full_name: null, email: null, avatar_url: null };
               }
             }
             return message;
@@ -147,39 +131,22 @@ export const useRealtimeMessages = (groupId: string | null) => {
           // The RPC returns a single row, which is our new message object
           const newMessage = data as Message;
           
-          // If profile data is missing, try to fetch it properly
           if (!newMessage.profiles || (!newMessage.profiles.full_name && !newMessage.profiles.email)) {
-            console.log('Profile data missing, fetching user info for user:', newMessage.user_id);
-            
+            console.log('Profile data missing for new message, fetching full user info for user:', newMessage.user_id);
             try {
-              // Try direct profiles table access
-              const { data: profileData, error: profileError } = await supabase
-                .from('profiles')
-                .select('id, full_name, email, avatar_url')
-                .eq('id', newMessage.user_id)
-                .maybeSingle();
+              const { data: profileData, error: rpcError } = await supabase
+                .rpc('get_user_profile_info', { p_user_id: newMessage.user_id })
+                .single();
 
-              if (!profileError && profileData) {
+              if (profileData && !rpcError) {
                 newMessage.profiles = profileData;
-                console.log('Successfully fetched profile data:', profileData);
               } else {
-                console.log('Could not fetch profile data, error:', profileError);
-                // Create empty profile if no data is available
-                newMessage.profiles = {
-                  id: newMessage.user_id,
-                  full_name: '',
-                  email: '',
-                  avatar_url: ''
-                };
+                if (rpcError) console.error('Error fetching profile info for new message:', rpcError.message);
+                newMessage.profiles = { id: newMessage.user_id, full_name: null, email: null, avatar_url: null };
               }
-            } catch (profileFetchError) {
-              console.log('Error fetching user data:', profileFetchError);
-              newMessage.profiles = {
-                id: newMessage.user_id,
-                full_name: '',
-                email: '',
-                avatar_url: ''
-              };
+            } catch (e) {
+              console.error('Exception fetching profile info for new message:', e);
+              newMessage.profiles = { id: newMessage.user_id, full_name: null, email: null, avatar_url: null };
             }
           }
           

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,18 +13,27 @@ export function generateAvatarUrl(seed?: string | null): string {
   return `https://api.dicebear.com/8.x/adventurer/svg?seed=${encodeURIComponent(seed)}`;
 }
 
-export function getProfileName(profile: { full_name?: string | null, email?: string | null } | null): string {
+export function getProfileName(
+  profile: { full_name?: string | null; email?: string | null } | null,
+  userId?: string | null
+): string {
   if (profile?.full_name) {
     return profile.full_name;
   }
   if (profile?.email) {
     const localPart = profile.email.split('@')[0];
-    // Prevent extremely long or empty local parts from being displayed
-    if (localPart && localPart.length < 30) {
+    // Use local part if it's a reasonable length
+    if (localPart && localPart.length > 0 && localPart.length < 30) {
       return localPart;
     }
-    // Fallback for very long or unusual emails
-    return profile.email;
+    // Otherwise, if it's a valid email, use the full thing
+    if (profile.email.includes('@')) {
+      return profile.email;
+    }
   }
-  return "Unknown User";
+  if (userId) {
+    return `User ${userId.substring(0, 8)}`;
+  }
+  // This should ideally not be reached if a userId is always provided for messages.
+  return 'User';
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,3 +12,19 @@ export function generateAvatarUrl(seed?: string | null): string {
   }
   return `https://api.dicebear.com/8.x/adventurer/svg?seed=${encodeURIComponent(seed)}`;
 }
+
+export function getProfileName(profile: { full_name?: string | null, email?: string | null } | null): string {
+  if (profile?.full_name) {
+    return profile.full_name;
+  }
+  if (profile?.email) {
+    const localPart = profile.email.split('@')[0];
+    // Prevent extremely long or empty local parts from being displayed
+    if (localPart && localPart.length < 30) {
+      return localPart;
+    }
+    // Fallback for very long or unusual emails
+    return profile.email;
+  }
+  return "Unknown User";
+}


### PR DESCRIPTION
This enhances the group chat functionality by ensuring that a user's name is always displayed, with a proper fallback mechanism.

A new helper function, `getProfileName`, has been added to `src/lib/utils.ts`. This function returns the user's `full_name` if available, falls back to the local part of their email, and finally defaults to "Unknown User".

The `GroupChat.tsx` component has been refactored to use the `getProfileName` function, simplifying the logic for displaying usernames and ensuring consistency.

The `useRealtimeMessages.ts` hook has been updated to use the `get_user_profile_info` RPC call to fetch user profile data. This makes the data fetching more robust and ensures that the necessary information is available for displaying usernames correctly.