### PR TITLE
Fix: Handle missing VAPID key and add notification button

### DIFF
--- a/src/hooks/useEnhancedAuth.ts
+++ b/src/hooks/useEnhancedAuth.ts
@@ -45,7 +45,14 @@ export const useEnhancedAuth = (): AuthState & AuthActions => {
         title: "Welcome Back",
         description: "You have been signed in successfully",
       });
-      notificationService.requestPermissionAndSubscribe();
+      notificationService.requestPermissionAndSubscribe().then(success => {
+        if (success) {
+          toast({
+            title: "Notifications Enabled",
+            description: "You will now receive push notifications.",
+          });
+        }
+      });
     }
   }, [toast]);
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ import useTaskNotifications from "@/hooks/useTaskNotifications";
 import { useIsMobile } from "@/hooks/use-mobile";
 import VoiceCommandButton from "@/components/VoiceCommandButton";
 import ThemeToggle from "@/components/ThemeToggle";
+import { notificationService } from "@/services/notificationService";
 import { generateAvatarUrl } from "@/lib/utils";
 
 interface Task {
@@ -164,6 +165,24 @@ const Dashboard = () => {
               <p className="text-sm text-muted-foreground">{user?.email}</p>
               <div className="mt-4 flex justify-center items-center space-x-2">
                   <ThemeToggle />
+                  <Button variant="ghost" size="sm" onClick={async () => {
+                    const success = await notificationService.requestPermissionAndSubscribe();
+                    if (success) {
+                      toast({
+                        title: "Notifications Enabled",
+                        description: "You will now receive push notifications.",
+                      });
+                    } else {
+                      toast({
+                        title: "Notifications Failed",
+                        description: "Could not enable push notifications. Please check your browser settings.",
+                        variant: "destructive",
+                      });
+                    }
+                  }}>
+                    <Bell className="mr-2 h-4 w-4" />
+                    Enable Notifications
+                  </Button>
                   <Button variant="ghost" size="sm" onClick={() => logout()}>
                     <LogOut className="mr-2 h-4 w-4" />
                     Sign Out

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -3,7 +3,11 @@ import { supabase } from '@/integrations/supabase/client';
 const VAPID_PUBLIC_KEY = import.meta.env.VITE_VAPID_PUBLIC_KEY;
 
 class NotificationService {
-  private async urlBase64ToUint8Array(base64String: string): Promise<Uint8Array> {
+  private async urlBase64ToUint8Array(base64String: string): Promise<Uint8Array | null> {
+    if (!base64String) {
+      console.error("VAPID public key is not defined. Push notifications will not work.");
+      return null;
+    }
     const padding = '='.repeat((4 - base64String.length % 4) % 4);
     const base64 = (base64String + padding)
       .replace(/-/g, '+')
@@ -16,17 +20,17 @@ class NotificationService {
     return outputArray;
   }
 
-  public async requestPermissionAndSubscribe(): Promise<void> {
+  public async requestPermissionAndSubscribe(): Promise<boolean> {
     if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
       console.warn('Push messaging is not supported');
-      return;
+      return false;
     }
 
     try {
       const permission = await Notification.requestPermission();
       if (permission !== 'granted') {
         console.log('Notification permission not granted.');
-        return;
+        return false;
       }
 
       const registration = await navigator.serviceWorker.ready;
@@ -35,6 +39,9 @@ class NotificationService {
       if (!subscription) {
         console.log('No existing subscription found, creating new one...');
         const applicationServerKey = await this.urlBase64ToUint8Array(VAPID_PUBLIC_KEY);
+        if (!applicationServerKey) {
+          return false;
+        }
         subscription = await registration.pushManager.subscribe({
           userVisibleOnly: true,
           applicationServerKey,
@@ -43,21 +50,24 @@ class NotificationService {
         console.log('Existing subscription found.');
       }
 
-      await this.saveSubscription(subscription);
+      return await this.saveSubscription(subscription);
     } catch (error) {
       console.error('Failed to subscribe to push notifications:', error);
+      return false;
     }
   }
 
-  private async saveSubscription(subscription: PushSubscription): Promise<void> {
+  private async saveSubscription(subscription: PushSubscription): Promise<boolean> {
     try {
       const { error } = await supabase.functions.invoke('push-subscribe', {
         body: { subscription },
       });
       if (error) throw error;
       console.log('Successfully saved push subscription.');
+      return true;
     } catch (error) {
       console.error('Error saving push subscription:', error);
+      return false;
     }
   }
 }


### PR DESCRIPTION
This commit resolves a TypeError that occurred when the VITE_VAPID_PUBLIC_KEY was not set, preventing push notification subscriptions.

The following changes have been made:
- Added a check in `urlBase64ToUint8Array` to prevent crashes when the VAPID key is missing.
- Modified `notificationService` methods to return a boolean indicating the success of the subscription.
- Added an 'Enable Notifications' button to the dashboard, which provides a toast notification on success or failure.
- Updated the sign-in flow to also provide a toast notification when push notifications are enabled.