### PR TITLE
Fix: Ensure VAPID key is available and add notification button

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,6 @@ export default defineConfig({
   define: {
     // This is a temporary workaround because the .env.local file is not being loaded in the environment.
     // Replace this with a proper environment variable loading mechanism for production.
-    'import.meta.env.VITE_VAPID_PUBLIC_KEY': JSON.stringify('BNo_b-26-OFj3WJgwFp-C9_s-T1d-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-Y_b-V6-d_b-YQ')
+    'import.meta.env.VITE_VAPID_PUBLIC_KEY': JSON.stringify('BM2c4e5esqI0pBEC85FpD1WNP-pSRseC2aOwdS82iPmuG822hJ1eAD2r5sLq00pZYTscsT3z1FcoDslj5Z3jJ8s')
   }
 });


### PR DESCRIPTION
This commit resolves a TypeError that occurred when the VITE_VAPID_PUBLIC_KEY was not set, preventing push notification subscriptions. It also fixes a subsequent encoding error with a faulty key.

The following changes have been made:
- Hardcoded a valid VAPID key in `vite.config.ts` as a workaround for environment loading issues. A comment is included to recommend a proper environment variable setup for production.
- Added a check in `urlBase64ToUint8Array` to prevent crashes when the VAPID key is missing.
- Modified `notificationService` methods to return a boolean indicating the success of the subscription.
- Added an 'Enable Notifications' button to the dashboard, which provides a toast notification on success or failure.
- Updated the sign-in flow to also provide a toast notification when push notifications are enabled.