### PR TITLE
Fix: Implement robust push notification system

### DIFF
--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -70,6 +70,25 @@ class NotificationService {
       return false;
     }
   }
+
+  public async sendTestNotification(userId: string): Promise<boolean> {
+    try {
+      const { error } = await supabase.functions.invoke('send-push', {
+        body: {
+          userId,
+          title: '🧪 Test Push Notification',
+          body: 'This is a real push notification from Aurora! It works!',
+          tag: 'test-push',
+        },
+      });
+      if (error) throw error;
+      console.log('Successfully triggered test push notification.');
+      return true;
+    } catch (error) {
+      console.error('Error sending test push notification:', error);
+      return false;
+    }
+  }
 }
 
 export const notificationService = new NotificationService();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,48 +1,50 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import path from "path"
 import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      strategies: 'injectManifest',
-      srcDir: 'public',
-      filename: 'sw.js',
-      devOptions: {
-        enabled: true
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        strategies: 'injectManifest',
+        srcDir: 'public',
+        filename: 'sw.js',
+        devOptions: {
+          enabled: true
+        },
+        manifest: {
+          name: 'Aurora',
+          short_name: 'Aurora',
+          description: 'AI-Powered Academic Planner',
+          theme_color: '#8B5CF6',
+          icons: [
+            {
+              src: 'pwa-192x192.png',
+              sizes: '192x192',
+              type: 'image/png'
+            },
+            {
+              src: 'pwa-512x512.png',
+              sizes: '512x512',
+              type: 'image/png'
+            }
+          ]
+        }
+      })
+    ],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
       },
-      manifest: {
-        name: 'Aurora',
-        short_name: 'Aurora',
-        description: 'AI-Powered Academic Planner',
-        theme_color: '#8B5CF6',
-        icons: [
-          {
-            src: 'pwa-192x192.png',
-            sizes: '192x192',
-            type: 'image/png'
-          },
-          {
-            src: 'pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png'
-          }
-        ]
-      }
-    })
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
     },
-  },
-  define: {
-    // This is a temporary workaround because the .env.local file is not being loaded in the environment.
-    // Replace this with a proper environment variable loading mechanism for production.
-    'import.meta.env.VITE_VAPID_PUBLIC_KEY': JSON.stringify('BM2c4e5esqI0pBEC85FpD1WNP-pSRseC2aOwdS82iPmuG822hJ1eAD2r5sLq00pZYTscsT3z1FcoDslj5Z3jJ8s')
+    define: {
+      'import.meta.env.VITE_VAPID_PUBLIC_KEY': JSON.stringify(env.VITE_VAPID_PUBLIC_KEY)
+    }
   }
 });


### PR DESCRIPTION
This commit resolves a series of issues related to push notifications, including a TypeError from a missing VAPID key, an invalid key encoding error, and a local-only test notification.

The following changes have been made:
- Reverted `vite.config.ts` to use the standard `loadEnv` method for loading the `VITE_VAPID_PUBLIC_KEY`, removing the hardcoded key.
- The `notificationService` now gracefully handles cases where the VAPID key is missing, preventing crashes.
- The "Test Notification" button now triggers a real, server-sent push notification by calling the `send-push` Supabase function.
- Added an "Enable Notifications" button and toast notifications to provide clear user feedback on the status of notification permissions and tests.