### PR TITLE
fix(push-notifications): Correct database migration and register canc…

### DIFF
--- a/supabase/migrations/20251126101407_update_push_subscriptions_p-key.sql
+++ b/supabase/migrations/20251126101407_update_push_subscriptions_p-key.sql
@@ -1,2 +1,2 @@
-ALTER TABLE push_subscriptions DROP CONSTRAINT push_subscriptions_user_id_key;
-ALTER TABLE push_subscriptions ADD PRIMARY KEY (endpoint);
+-- Drop the unique constraint on user_id to allow multiple subscriptions per user
+ALTER TABLE public.push_subscriptions DROP CONSTRAINT IF EXISTS push_subscriptions_user_id_key;


### PR DESCRIPTION
…el function

This commit fixes the push notification system by:
- Correcting the database migration to allow multiple subscriptions per user. The faulty unique constraint on `user_id` is removed, while the existing unique constraint on `endpoint` is retained for `upsert` operations.
- Registering the `cancel-notification` function in `supabase/config.toml` so it can be deployed and invoked by the frontend.

These changes resolve the 500 Internal Server Error when subscribing to notifications and ensure that notifications for completed tasks can be successfully canceled.